### PR TITLE
라이프 추가 & 잘못된 person을 눌렀을 때 라이프 줄이기

### DIFF
--- a/src/objects/playInfo.ts
+++ b/src/objects/playInfo.ts
@@ -3,8 +3,9 @@ import canvas, { drawLayer } from '../canvas';
 import { getFont } from '../utils';
 
 type PlayInfoState = {
-  stage: number,
-  timeout: number,
+  stage: number;
+  timeout: number;
+  lifeCount: number;
 };
 
 export default class PlayInfo implements GameObject, PlayInfoState {
@@ -12,13 +13,16 @@ export default class PlayInfo implements GameObject, PlayInfoState {
   stage: number;
   startTime: number; // ms
   timeout: number; // ms
+  lifeCount: number;
 
-  init = ({
-    stage,
-    timeout,
-  }: PlayInfoState) => {
+  constructor() {
+    this.layer = canvas.get('layer3');
+  }
+
+  init = ({ stage, timeout, lifeCount }: PlayInfoState) => {
     this.stage = stage;
     this.timeout = timeout;
+    this.lifeCount = lifeCount;
   };
 
   remove = () => {};
@@ -30,43 +34,59 @@ export default class PlayInfo implements GameObject, PlayInfoState {
 
     this.#drawStage();
     this.#drawTimer(time);
+    this.#drawLife();
   };
 
   #drawStage = () => {
-    const playInfoLayer = canvas.get('layer3');
-    const draw = drawLayer(playInfoLayer);
+    const draw = drawLayer(this.layer);
 
     draw((context) => {
-      context.setTransform(
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      );
+      context.setTransform(1, 0, 0, 1, 0, 0);
       context.font = getFont(24);
       context.fillText(`Stage ${this.stage}`, 40, 56);
     });
   };
 
   #drawTimer = (time: number) => {
-    const playInfoLayer = canvas.get('layer3');
-    const draw = drawLayer(playInfoLayer);
+    const draw = drawLayer(this.layer);
 
     draw((context, canvas) => {
-      const remainTime = (Math.max(this.timeout - (time - this.startTime), 0) / 1000).toFixed(2);
+      const remainTime = (
+        Math.max(this.timeout - (time - this.startTime), 0) / 1000
+      ).toFixed(2);
 
-      context.setTransform(
-        1,
-        0,
-        0,
-        1,
-        canvas.width,
-        0,
-      );
+      context.setTransform(1, 0, 0, 1, canvas.width, 0);
       context.font = getFont(24);
       context.fillText(remainTime + '', -120, 56);
     });
+  };
+
+  #drawLife = () => {
+    const draw = drawLayer(this.layer);
+    const width = 50;
+    const height = 50;
+    const offset = 80;
+    const d = Math.min(width, height);
+    [...new Array(this.lifeCount)].forEach((_, index) => {
+      draw((context, canvas) => {
+        context.strokeStyle = '#000000';
+        context.shadowOffsetX = 4.0;
+        context.shadowOffsetY = 4.0;
+        context.lineWidth = 6.0;
+        context.fillStyle = '#FF0000';
+        context.setTransform(1, 0, 0, 1, 40 + offset * index, canvas.height - 100);
+        context.moveTo(0, d / 4);
+        context.quadraticCurveTo(0, 0, d / 4, 0);
+        context.quadraticCurveTo(d / 2, 0, d / 2, d / 4);
+        context.quadraticCurveTo(d / 2, 0, (d * 3) / 4, 0);
+        context.quadraticCurveTo(d, 0, d, d / 4);
+        context.quadraticCurveTo(d, d / 2, (d * 3) / 4, (d * 3) / 4);
+        context.lineTo(d / 2, d);
+        context.lineTo(d / 4, (d * 3) / 4);
+        context.quadraticCurveTo(0, d / 2, 0, d / 4);
+        context.stroke();
+        context.fill();
+      });
+    })
   };
 }

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -9,7 +9,6 @@ import { getRandomColor, getRandomInt, pickRandomOption } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
 import playMusic from '../sounds/musics/play';
-import store from '../store';
 
 export default class PlayScene implements Scene {
   activeBackground: BackgroundType;
@@ -19,8 +18,6 @@ export default class PlayScene implements Scene {
   layer1: HTMLCanvasElement;
   persons: Person[];
   wantedPoster: WantedPoster;
-  stage: number = 0;
-  timeout: number = 10000;
   music = new Music(playMusic);
 
   constructor() {
@@ -41,8 +38,9 @@ export default class PlayScene implements Scene {
     this.backgrounds[this.activeBackground].init();
     this.music.play(true);
     this.info.init({
-      stage: this.stage,
-      timeout: this.timeout,
+      stage: 1,
+      timeout: 10000,
+      lifeCount: 5,
     });
 
     this.persons = [...new Array(100)].map(() => new Person());

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -77,7 +77,10 @@ export default class PlayScene implements Scene {
     });
 
     window.addEventListener('click', (e: PointerEvent) => {
-      wantedPersons.forEach((person) => {
+      let isPersonClicked = false;
+      let isCorrect = false;
+
+      this.persons.forEach((person) => {
         if (person.isHit) return;
 
         person.setIsHit({
@@ -86,10 +89,18 @@ export default class PlayScene implements Scene {
         });
 
         if (person.isHit) {
-          alert(`You hit PersonId:${person.id}!`);
-          this.wantedPoster.removePerson(person.id);
+          isPersonClicked = true;
+          if (person.id < this.wantedPoster.persons.length) {
+            isCorrect = true;
+            alert(`You hit PersonId:${person.id}!`);
+            this.wantedPoster.removePerson(person.id);
+          }
         }
       });
+
+      if (isPersonClicked && !isCorrect) {
+        this.info.lifeCount = Math.max(0, this.info.lifeCount - 1);
+      }
     });
   };
 


### PR DESCRIPTION
## 구현 내용
- 라이프를 구현합니다. 원래는 `Life` 라는 이름의 게임 오브젝트를 따로 만들 생각이었으나, 작성되어 있는 `PlayInfo`와도 겹치는 부분이 있는 것 같아 여기에 추가로 작업하는 방향으로 진행하였습니다.
- 클릭했을 때, 정답이 아닌 경우에는 라이프를 1씩 줄입니다.

## 고려되어야 할 부분
- 현재 클릭한 위치에 person이 겹쳐있는 경우에 대해서는, 일타쌍피가 가능한 문제가 있습니다. 이 문제에 대해서는 기존에 이야기 나왔던 캐릭터의 z축 관련 문제와 더불어 고민되어야 할 것 같습니다. :)