### PR TITLE
타이틀 메뉴의 마우스 클릭 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 zip/
 .DS_Store
+.vscode/

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -1,5 +1,6 @@
 import { GameObject } from '.';
 import canvas, { drawLayer } from '../canvas';
+import { Rect } from '../types/rect';
 import { degreeToRadian, getRandomInteger, getTimings } from '../utils';
 
 type ColorState = {
@@ -19,15 +20,6 @@ type PersonState = {
     z: number;
   };
   colors: ColorState;
-};
-
-type Rect = {
-  left: number;
-  width: number;
-  right: number;
-  top: number;
-  height: number;
-  bottom: number;
 };
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];

--- a/src/scenes/title.ts
+++ b/src/scenes/title.ts
@@ -29,6 +29,8 @@ export default class TitleScene implements Scene {
   ];
   music = new Music(titleMusic);
 
+  
+
   start = () => {
     this.activeMenuIndex = 0;
     this.#addEvents();
@@ -49,6 +51,25 @@ export default class TitleScene implements Scene {
   #addEvents = () => {
     window.addEventListener('keydown', this.#changeMenuIndexEvent);
     window.addEventListener('keydown', this.#actionEvent);
+
+    window.addEventListener('click', (e: PointerEvent) => {
+      const { clientX, clientY } = e;
+
+
+      // const { width, height } = canvas;
+      // const { x, y } = this.menus[this.activeMenuIndex];
+      // const { width: menuWidth, height: menuHeight } = this.menus[
+      //   this.activeMenuIndex
+      // ];
+      // if (
+      //   clientX >= x &&
+      //   clientX <= x + menuWidth &&
+      //   clientY >= y &&
+      //   clientY <= y + menuHeight
+      // ) {
+      //   this.menus[this.activeMenuIndex].action();
+      // }
+    });
   };
 
   #removeEvents = () => {
@@ -60,7 +81,10 @@ export default class TitleScene implements Scene {
     playEffectSound('pick');
 
     if (e.code === 'ArrowDown') {
-      this.activeMenuIndex = Math.min(this.activeMenuIndex + 1, this.menus.length - 1);
+      this.activeMenuIndex = Math.min(
+        this.activeMenuIndex + 1,
+        this.menus.length - 1,
+      );
     }
 
     if (e.code === 'ArrowUp') {
@@ -74,7 +98,7 @@ export default class TitleScene implements Scene {
     const currentMenu = this.menus[this.activeMenuIndex];
     currentMenu.action();
   };
-  
+
   #changeScene = (sceneType: SceneType) => {
     window.postMessage(
       {
@@ -120,14 +144,7 @@ export default class TitleScene implements Scene {
       context.font = getFont(12);
       context.fillText('Start', 0, 0);
 
-      context.transform(
-        1,
-        0,
-        0,
-        1,
-        -20,
-        40,
-      );
+      context.transform(1, 0, 0, 1, -20, 40);
       context.font = getFont(12);
 
       const isSoundOn = store.isSoundOn ? 'on' : 'off';

--- a/src/types/rect.ts
+++ b/src/types/rect.ts
@@ -1,0 +1,8 @@
+export type Rect = {
+  left: number;
+  width: number;
+  right: number;
+  top: number;
+  height: number;
+  bottom: number;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { Rect } from './types/rect';
+
 export const degreeToRadian = (degree: number) => (Math.PI / 180) * degree;
 
 interface GetTimingProps {
@@ -51,5 +53,14 @@ export const getLinearPosition = ({
   maxWidth,
   time,
   offset,
-}: LinearPosition) =>
-  (x + time) % (maxWidth + offset) - offset;
+}: LinearPosition) => ((x + time) % (maxWidth + offset)) - offset;
+
+export const isInsideRect = (
+  position: { x: number; y: number },
+  rect: Rect,
+) => {
+  const { left, right, top, bottom } = rect;
+  const { x, y } = position;
+
+  return left <= x && x <= right && top <= y && y <= bottom;
+};


### PR DESCRIPTION
## 작업 내용

- 타이틀 메뉴를 마우스로 클릭 가능하도록 기능을 추가합니다.

## 기타 사항
- 올바른 위치에 마우스를 클릭했는지 판단하는 기준은 `this.hitBoxes`의 위치값으로 판단합니다. `setTransform` 이후에는 좌표계가 변하기 때문에 `this.hitBoxes`의 좌표는 `setTransform`을 실행하기 전에 설정합니다.
- `this.hitBoxes` 변수는 타이틀 메뉴 아이템(ex. `start`, `sound`)을 어디에 그리느냐에 의존하고 있습니다.
- 따라서 메뉴 아이템의 위치, 사이즈, 폰트 사이즈를 수정해야 할 경우 히트박스의 좌표도 변경해야 하므로 하드코딩 값을 변수로 묶어 두었습니다:

```ts
const hitBoxpadding = 3;
const fontSize = 12;
const startTextWidth = 45 + hitBoxpadding * 2;
const startTextHeight = fontSize + hitBoxpadding * 2;
const soundTextWidth = 104 + hitBoxpadding * 2;
const soundTextHeight = fontSize + hitBoxpadding * 2;

const startTextPosition = {
  x: canvas.width / 2 - 20,
  y: canvas.height / 2 - 100,
};

const soundTextOffsetFromStartText = {
  x: -20,
  y: 40,
};
```

## 데모

https://user-images.githubusercontent.com/8105528/188461809-2493de20-e65b-4c07-9f3f-85db651c261f.mov

