### PR TITLE
배리어 영역을 canvas 사이즈에 대해 반응형으로 설정

### DIFF
--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -1,7 +1,7 @@
 import { GameObject } from '.';
 import canvas, { drawLayer } from '../canvas';
 import { RectType, Rect } from '../types/rect';
-import { degreeToRadian, getBarrierSize, getRandomIntegerFromRange, getTimings } from '../utils';
+import { degreeToRadian, barrierRectFactory, getRandomIntegerFromRange, getTimings } from '../utils';
 
 type ColorState = {
   hair: string;
@@ -241,17 +241,6 @@ export default class Person implements GameObject, PersonState {
     const drawLayer2 = drawLayer(layer2);
     
     drawLayer1((context, canvas) => {
-      const { width, height } = getBarrierSize(canvas)
-      this.barrier = new Rect({
-        left: canvas.width / 2 - width / 2,
-        top: canvas.height / 2 - height / 2,
-        width,
-        height,
-      })
-
-      this.#drawBarrier(context)
-      
-
       const sizeRatio = 0.6 + 0.4 * (this.position.z / canvas.height);
       this.#setHitBoxPosition();
       this.#drawShadow(context, canvas, time, this.position, sizeRatio);
@@ -277,33 +266,28 @@ export default class Person implements GameObject, PersonState {
       }
     });
     drawLayer2((context, canvas) => {
-      const { width, height } = getBarrierSize(canvas)
-      this.barrier = new Rect({
-        left: canvas.width / 2 - width / 2,
-        top: canvas.height / 2 - height / 2,
-        width,
-        height,
-      })
+      this.barrier = barrierRectFactory(canvas)
 
-      this.#drawBarrier(context)
+      // debug
+      // this.#drawBarrier(context)
 
       if (this.position.x <= this.barrier.left) {
-        this.position.x = this.barrier.left + 10;
+        this.position.x = this.barrier.left + 1;
         this.move.direction.x = 1;
       }
 
       if (this.position.x >= this.barrier.right) {
-        this.position.x = this.barrier.right - 10;
+        this.position.x = this.barrier.right - 1;
         this.move.direction.x = -1;
       }
 
       if (this.position.y <= this.barrier.top) {
-        this.position.y = this.barrier.top + 10;
+        this.position.y = this.barrier.top + 1;
         this.move.direction.y = 1;
       }
 
       if (this.position.y >= this.barrier.bottom) {
-        this.position.y = this.barrier.bottom - 10;
+        this.position.y = this.barrier.bottom - 1;
         this.move.direction.y = -1;
       }
 

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -5,7 +5,7 @@ import { BackgroundType, Playground, Pool, Road } from '../objects/backgrounds';
 import PlayInfo from '../objects/playInfo';
 import Magnifier from '../objects/magnifier';
 import Person, { EYE_COLORS, LOWER_BODY_SIZE, SKIN_COLORS } from '../objects/person';
-import { getRandomColor, getRandomIntegerFromRange, pickRandomOption } from '../utils';
+import { barrierRectFactory, getRandomColor, getRandomIntegerFromRange, pickRandomOption } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
 import playMusic from '../sounds/musics/play';
@@ -47,12 +47,7 @@ export default class PlayScene implements Scene {
     this.layer1 = canvas.get('layer1');
     this.wantedPoster = new WantedPoster();
     this.music = new Music(playMusic);
-    this.barrier = new Rect({
-      left: this.layer1.width / 5,
-      top: this.layer1.height / 5,
-      width: this.layer1.width / 5 * 3,
-      height: this.layer1.height / 5 * 3,
-    })
+    this.barrier = barrierRectFactory(this.layer1)
   }
 
   start = ({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { RectType } from './types/rect';
+import { Rect, RectType } from './types/rect';
 
 export const degreeToRadian = (degree: number) => (Math.PI / 180) * degree;
 
@@ -78,17 +78,16 @@ export const isInsideRect = (
   return left <= x && x <= right && top <= y && y <= bottom;
 };
 
-const sm = {
-  width: 640,
-  height: 380,
-}
+export const barrierRectFactory = (canvas: HTMLCanvasElement) => {
+  const skyHeight = 150;
+  const posterHeight = 200;
+  const width = canvas.width * 0.99
 
-const md = {
-  width: 800,
-  height: 600,
-}
-
-export const getBarrierSize = (canvas: HTMLCanvasElement) => {
-  return canvas.width > md.width ? md : sm;
+  return new Rect({
+    left: canvas.width / 2 - width / 2,
+    top: skyHeight,
+    width: canvas.width * 0.99,
+    height: canvas.height - skyHeight - posterHeight,
+  })
 }
 


### PR DESCRIPTION
## 작업 내용

- 배리어 영역을 canvas 사이즈에 대해 반응형으로 설정합니다.
- 배경을 최대한 활용하기 위해 배리어의 top은 하늘 바로 아래에서 시작하고, wantedPoster를 넘어서지 않도록 합니다. width는 최대한 넓힙니다.

## 데모

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/8105528/189286478-337ba2f2-fcd1-49da-8f8e-a9a0d1444dc7.png">


<img width="1141" alt="image" src="https://user-images.githubusercontent.com/8105528/189286453-d052deb7-d8ab-4afb-b087-d8110af9a1c5.png">
