### PR TITLE
y축 기준으로 가장 앞에 있는 frontman만 hit하는 기능 추가

### DIFF
--- a/src/objects/magnifier.ts
+++ b/src/objects/magnifier.ts
@@ -67,8 +67,8 @@ export default class Magnifier implements GameObject, MagnifierState {
 
   #handleMouseMove = (e: MouseEvent) => {
     this.position = {
-      x: e.clientX,
-      y: e.clientY,
+      x: e.offsetX,
+      y: e.offsetY,
     };
   };
 }

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -35,15 +35,16 @@ export const SKIN_COLORS = [
 export const LOWER_BODY_SIZE = 18
 const PADDING = 10;
 const SPEED_MAX_MULTIPLE = 0.3;
-const SPEED_MIN_MULTIPLE = -1;
+const SPEED_MIN_MULTIPLE = -0.7;
 
 const DISTANCE_PER_SECOND = 24;
 const FRAME_RATE_PER_SECOND = 60;
 
 /**
- * @description 1초 동안 움직이는 픽셀 거리
+ * @description 1프레임 동안 움직이는 픽셀 거리
  */
 const DEFAULT_SPEED = DISTANCE_PER_SECOND / FRAME_RATE_PER_SECOND;
+const MIN_SPEED = 0.1
 
 export default class Person implements GameObject, PersonState {
   id: number;
@@ -155,15 +156,15 @@ export default class Person implements GameObject, PersonState {
 
   #moveRandomX = () => {
     this.isMoving = true;
-    this.#moveX(this.defaultSpeed * (1 + this.randomX));
+    this.#moveX(this.defaultSpeed * (1 + this.randomX) + MIN_SPEED);
 
     this.#stayInBarrier();
   };
 
   #moveRandomXY = () => {
     this.isMoving = true;
-    this.#moveX(this.defaultSpeed * (1 + this.randomX));
-    this.#moveY(this.defaultSpeed * (1 + this.randomY) * 0.6);
+    this.#moveX(this.defaultSpeed * (1 + this.randomX) + MIN_SPEED);
+    this.#moveY(this.defaultSpeed * (1 + this.randomY) * 0.6 + MIN_SPEED);
 
     this.#stayInBarrier();
   };
@@ -187,8 +188,8 @@ export default class Person implements GameObject, PersonState {
   #moveSpeedDownGentleSlope = (progress?: number) => {
     this.isMoving = true;
     if (progress === 1) return (this.isMoving = false);
-    this.#moveX(this.defaultSpeed * (1 - progress));
-    this.#moveY(this.defaultSpeed * 0.2 * (1 - progress));
+    this.#moveX(this.defaultSpeed * (1 - progress) + MIN_SPEED);
+    this.#moveY(this.defaultSpeed * 0.2 * (1 - progress) + MIN_SPEED);
 
     this.#stayInBarrier();
   };
@@ -198,8 +199,8 @@ export default class Person implements GameObject, PersonState {
     if (progress === 1) return (this.isMoving = false);
 
     const naturalizedProgress = Math.max(0.8, progress);
-    this.#moveX(this.defaultSpeed * (1 - naturalizedProgress));
-    this.#moveY(this.defaultSpeed * (1 - naturalizedProgress));
+    this.#moveX(this.defaultSpeed * (1 - naturalizedProgress) + MIN_SPEED);
+    this.#moveY(this.defaultSpeed * (1 - naturalizedProgress) + MIN_SPEED);
 
     this.#stayInBarrier();
   };

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -1,7 +1,7 @@
 import { GameObject } from '.';
 import canvas, { drawLayer } from '../canvas';
 import { RectType, Rect } from '../types/rect';
-import { degreeToRadian, getBarrierSize, getRandomIntegerFromRange, getTimings } from '../utils';
+import { degreeToRadian, barrierRectFactory, getRandomIntegerFromRange, getTimings } from '../utils';
 
 type ColorState = {
   hair: string;
@@ -241,17 +241,6 @@ export default class Person implements GameObject, PersonState {
     const drawLayer2 = drawLayer(layer2);
     
     drawLayer1((context, canvas) => {
-      const { width, height } = getBarrierSize(canvas)
-      this.barrier = new Rect({
-        left: canvas.width / 2 - width / 2,
-        top: canvas.height / 2 - height / 2,
-        width,
-        height,
-      })
-
-      this.#drawBarrier(context)
-      
-
       const sizeRatio = 0.6 + 0.4 * (this.position.z / canvas.height);
       this.#setHitBoxPosition();
       this.#drawShadow(context, canvas, time, this.position, sizeRatio);
@@ -277,33 +266,28 @@ export default class Person implements GameObject, PersonState {
       }
     });
     drawLayer2((context, canvas) => {
-      const { width, height } = getBarrierSize(canvas)
-      this.barrier = new Rect({
-        left: canvas.width / 2 - width / 2,
-        top: canvas.height / 2 - height / 2,
-        width,
-        height,
-      })
+      this.barrier = barrierRectFactory(canvas)
 
-      this.#drawBarrier(context)
+      // debug
+      // this.#drawBarrier(context)
 
       if (this.position.x <= this.barrier.left) {
-        this.position.x = this.barrier.left + 10;
+        this.position.x = this.barrier.left + 1;
         this.move.direction.x = 1;
       }
 
       if (this.position.x >= this.barrier.right) {
-        this.position.x = this.barrier.right - 10;
+        this.position.x = this.barrier.right - 1;
         this.move.direction.x = -1;
       }
 
       if (this.position.y <= this.barrier.top) {
-        this.position.y = this.barrier.top + 10;
+        this.position.y = this.barrier.top + 1;
         this.move.direction.y = 1;
       }
 
       if (this.position.y >= this.barrier.bottom) {
-        this.position.y = this.barrier.bottom - 10;
+        this.position.y = this.barrier.bottom - 1;
         this.move.direction.y = -1;
       }
 

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -226,15 +226,6 @@ export default class Person implements GameObject, PersonState {
     return;
   };
 
-  setIsHit = (shotPosition: { x: number; y: number }) => {
-    const { left, right, top, bottom } = this.hitBoxPosition;
-    const { x: shotX, y: shotY } = shotPosition;
-
-    left <= shotX && shotX <= right && top <= shotY && shotY <= bottom
-      ? (this.isHit = true)
-      : (this.isHit = false);
-  };
-
   draw = (time: number) => {
     const layer1 = canvas.get('layer1'); // 확대
     const drawLayer1 = drawLayer(layer1);

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -5,7 +5,7 @@ import { BackgroundType, Playground, Pool, Road } from '../objects/backgrounds';
 import PlayInfo from '../objects/playInfo';
 import Magnifier from '../objects/magnifier';
 import Person, { EYE_COLORS, LOWER_BODY_SIZE, SKIN_COLORS } from '../objects/person';
-import { getRandomColor, getRandomIntegerFromRange, pickRandomOption } from '../utils';
+import { barrierRectFactory, getRandomColor, getRandomIntegerFromRange, pickRandomOption } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
 import playMusic from '../sounds/musics/play';
@@ -47,12 +47,7 @@ export default class PlayScene implements Scene {
     this.layer1 = canvas.get('layer1');
     this.wantedPoster = new WantedPoster();
     this.music = new Music(playMusic);
-    this.barrier = new Rect({
-      left: this.layer1.width / 5,
-      top: this.layer1.height / 5,
-      width: this.layer1.width / 5 * 3,
-      height: this.layer1.height / 5 * 3,
-    })
+    this.barrier = barrierRectFactory(this.layer1)
   }
 
   start = ({

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -154,8 +154,8 @@ export default class PlayScene implements Scene {
       if (person.isHit) return;
 
       person.setIsHit({
-        x: e.clientX,
-        y: e.clientY,
+        x: e.offsetX,
+        y: e.offsetY,
       });
 
       if (person.isHit) {

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -5,7 +5,7 @@ import { BackgroundType, Playground, Pool, Road } from '../objects/backgrounds';
 import PlayInfo from '../objects/playInfo';
 import Magnifier from '../objects/magnifier';
 import Person, { EYE_COLORS, LOWER_BODY_SIZE, SKIN_COLORS } from '../objects/person';
-import { barrierRectFactory, getRandomColor, getRandomIntegerFromRange, pickRandomOption } from '../utils';
+import { barrierRectFactory, getRandomColor, getRandomIntegerFromRange, isInsideRect, pickRandomOption } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
 import playMusic from '../sounds/musics/play';
@@ -138,37 +138,33 @@ export default class PlayScene implements Scene {
     }
   }
 
-  // debug
-  #drawPersonBarrier = (context: CanvasRenderingContext2D) => {
-    context.resetTransform()
-    context.beginPath();
-    context.strokeRect(this.barrier.left, this.barrier.top, this.barrier.width, this.barrier.height);
-    context.closePath();
-  }
-
   #handleClickPerson = (e: PointerEvent) => {
     let isPersonClicked = false;
     let isCorrect = false;
+    let clickedPersons: Person[] = [];
 
     this.persons.forEach((person) => {
       if (person.isHit) return;
 
-      person.setIsHit({
+      isInsideRect({
         x: e.offsetX,
         y: e.offsetY,
-      });
+      }, person.hitBoxPosition) && clickedPersons.push(person);
+    })
 
-      if (person.isHit) {
-        isPersonClicked = true;
-        if (person.id < this.wantedPersonCount) {
-          isCorrect = true;
-          this.wantedPoster.removePerson(person.id);
-          person.correctAt = performance.now();
-        } else {
-          person.deadAt = performance.now();
-        }
+    const [frontPerson] = clickedPersons.sort((a, b) => b.position.y - a.position.y);
+    frontPerson.isHit = true;
+
+    if (frontPerson.isHit) {
+      isPersonClicked = true;
+      if (frontPerson.id < this.wantedPersonCount) {
+        isCorrect = true;
+        this.wantedPoster.removePerson(frontPerson.id);
+        frontPerson.correctAt = performance.now();
+      } else {
+        frontPerson.deadAt = performance.now();
       }
-    });
+    }
 
     if (isPersonClicked) {
       if (!isCorrect) {
@@ -178,5 +174,13 @@ export default class PlayScene implements Scene {
         playEffectSound('correct');
       }
     }
+  }
+
+  // debug
+  #drawPersonBarrier = (context: CanvasRenderingContext2D) => {
+    context.resetTransform()
+    context.beginPath();
+    context.strokeRect(this.barrier.left, this.barrier.top, this.barrier.width, this.barrier.height);
+    context.closePath();
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,12 +81,12 @@ export const isInsideRect = (
 export const barrierRectFactory = (canvas: HTMLCanvasElement) => {
   const skyHeight = 150;
   const posterHeight = 200;
-  const width = canvas.width * 0.99
+  const width = canvas.width * 0.99;
 
   return new Rect({
     left: canvas.width / 2 - width / 2,
     top: skyHeight,
-    width: canvas.width * 0.99,
+    width,
     height: canvas.height - skyHeight - posterHeight,
   })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { RectType } from './types/rect';
+import { Rect, RectType } from './types/rect';
 
 export const degreeToRadian = (degree: number) => (Math.PI / 180) * degree;
 
@@ -78,17 +78,16 @@ export const isInsideRect = (
   return left <= x && x <= right && top <= y && y <= bottom;
 };
 
-const sm = {
-  width: 640,
-  height: 380,
-}
+export const barrierRectFactory = (canvas: HTMLCanvasElement) => {
+  const skyHeight = 150;
+  const posterHeight = 200;
+  const width = canvas.width * 0.99
 
-const md = {
-  width: 800,
-  height: 600,
-}
-
-export const getBarrierSize = (canvas: HTMLCanvasElement) => {
-  return canvas.width > md.width ? md : sm;
+  return new Rect({
+    left: canvas.width / 2 - width / 2,
+    top: skyHeight,
+    width: canvas.width * 0.99,
+    height: canvas.height - skyHeight - posterHeight,
+  })
 }
 


### PR DESCRIPTION
## 작업 내용

- y축 기준으로 가장 앞에 있는 frontman만 hit하는 기능 추가
- Person 제자리 걸음하지 않도록 최소 속력 추가
- 돋보기와 person.setIsHit의 기준을 offset으로 변경

## 데모

> y값이 가장 큰 사람만 hit하는지 체크합니다. 발을 기준으로 발이 가장 아래에 있는 사람이 먼저 사라집니다.

https://user-images.githubusercontent.com/8105528/189298666-27762ef0-a588-45f2-a630-a987170dd6f3.mov

> wanted person과 일반 사람이 겹쳤을 때 클릭했는데 일반 사람이 frontman일 경우 일반 사람이 사라집니다.


https://user-images.githubusercontent.com/8105528/189299031-ad2a3bce-a69e-4499-9f21-acc25b1f8485.mov



## 부모 PR 

#19 