### PR TITLE
Person 바리에이션 추가 & 캔버스 크기 유지 및 마우스 포지션 조정

### DIFF
--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -55,20 +55,6 @@ export const createCanvas = (id: string) => {
 
   resizeCanvas(canvas);
 
-  canvas.addEventListener('click', (event: PointerEvent) => {
-    window.postMessage(
-      {
-        type: 'click-canvas',
-        payload: {
-          id,
-          x: event.clientX,
-          y: event.clientY,
-        },
-      },
-      window.origin,
-    );
-  });
-
   return canvas;
 };
 
@@ -79,8 +65,25 @@ export const removeCanvas = (id: string) => {
 };
 
 export const resizeCanvas = (canvas: HTMLCanvasElement) => {
-  canvas.width = Math.min( window.innerWidth, window.innerHeight);
-  canvas.height = Math.min( window.innerWidth, window.innerHeight);
+  canvas.width = 920;
+  canvas.height = 920;
+  if (window.innerWidth > window.innerHeight) {
+    Object.assign(
+      canvas.style,
+      {
+        width: 'auto',
+        height: '100%',
+      }
+    )
+  } else {
+    Object.assign(
+      canvas.style,
+      {
+        width: '100%',
+        height: 'auto',
+      }
+    )
+  }
 };
 
 export const drawLayer = (canvas: HTMLCanvasElement) => {

--- a/src/game.ts
+++ b/src/game.ts
@@ -8,7 +8,7 @@ export default class Game {
   scenes: { [name in SceneType]: Scene };
 
   constructor() {
-    this.activeScene = 'title';
+    this.activeScene = 'play';
     this.scenes = {
       play: new PlayScene(),
       title: new TitleScene(),

--- a/src/game.ts
+++ b/src/game.ts
@@ -8,7 +8,7 @@ export default class Game {
   scenes: { [name in SceneType]: Scene };
 
   constructor() {
-    this.activeScene = 'play';
+    this.activeScene = 'title';
     this.scenes = {
       play: new PlayScene(),
       title: new TitleScene(),

--- a/src/objects/magnifier.ts
+++ b/src/objects/magnifier.ts
@@ -1,5 +1,6 @@
 import { GameObject } from '.';
 import canvas, { drawLayer } from '../canvas';
+import { getMousePosition } from '../utils';
 
 type MagnifierState = {
   position: {
@@ -75,9 +76,6 @@ export default class Magnifier implements GameObject, MagnifierState {
   };
 
   #handlePointerMove = (e: MouseEvent) => {
-    this.position = {
-      x: e.offsetX,
-      y: e.offsetY,
-    };
+    this.position = getMousePosition(this.layer1, e);
   };
 }

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -35,7 +35,8 @@ type Variation =
   | 'beanie'
   | 'cap'
   | 'hat'
-  | 'longHair';
+  | 'longHair'
+  | 'short';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -94,7 +95,8 @@ export default class Person implements GameObject, PersonState {
     beanie: false,
     cap: false,
     hat: false,
-    longHair: true,
+    longHair: false,
+    short: true,
   };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -512,6 +514,11 @@ export default class Person implements GameObject, PersonState {
       context.fillRect(-10, -62, 24, 12);
       context.fillRect(-14, -62, 4, 16);
       context.fillRect(8, -58, 12, 48);
+    } else if (this.variations.short) {
+      context.fillStyle = this.colors.hair;
+      context.fillRect(-8, -62, 20, 12);
+      context.fillRect(-14, -60, 9, 16);
+      context.fillRect(8, -58, 6, 8);
     } else {
       context.fillStyle = this.colors.hair;
       context.fillRect(-16, -62, 28, 12);
@@ -524,11 +531,9 @@ export default class Person implements GameObject, PersonState {
     }
     if (this.variations.beanie) {
       this.#drawBeanie(context);
-    }
-    if (this.variations.cap) {
+    } else if (this.variations.cap) {
       this.#drawCap(context);
-    }
-    if (this.variations.hat) {
+    } else if (this.variations.hat) {
       this.#drawHat(context);
     }
   };

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -23,7 +23,7 @@ type PersonState = {
   barrier: Rect;
 };
 
-type Variation = 'glasses' | 'bald';
+type Variation = 'glasses' | 'sunglassses' | 'bald'  ;
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -76,7 +76,8 @@ export default class Person implements GameObject, PersonState {
   variations: {
     [key in Variation]: boolean;
   } = {
-    glasses: true,
+    glasses: false,
+    sunglassses: true,
     bald: true,
   }
 
@@ -484,6 +485,8 @@ export default class Person implements GameObject, PersonState {
     }
     if (this.variations.glasses) {
       this.#drawGlasses(context);
+    } else if (this.variations.sunglassses) {
+      this.#drawSunGlasses(context);
     }
   };
 
@@ -844,6 +847,14 @@ export default class Person implements GameObject, PersonState {
     context.stroke();
     context.fillRect(9, -45, 4, 2);
     context.closePath();
+  }
+
+  #drawSunGlasses = (context: CanvasRenderingContext2D) => {
+    context.fillStyle = '#000'
+    context.fillRect(-2, -48, 10, 8);
+    context.fillRect(-12, -48, 8, 8);
+    context.fillRect(7, -46, 6, 2);
+    context.fillRect(-8, -46, 6, 2);
   }
 
   #drawBarrier = (context: CanvasRenderingContext2D) => {

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -36,7 +36,8 @@ type Variation =
   | 'cap'
   | 'hat'
   | 'longHair'
-  | 'short';
+  | 'short'
+  | 'sleeveless';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -96,7 +97,8 @@ export default class Person implements GameObject, PersonState {
     cap: false,
     hat: false,
     longHair: false,
-    short: true,
+    short: false,
+    sleeveless: true,
   };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -539,15 +541,30 @@ export default class Person implements GameObject, PersonState {
   };
 
   #drawArm = (context: CanvasRenderingContext2D) => {
-    context.fillStyle = this.colors.top;
-    context.fillRect(-12, 0, 8, 38);
-    context.fillStyle = this.colors.skin;
-    context.fillRect(-12, 38, 8, 8);
+    if (this.variations.sleeveless) {
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-12, 0, 8, 38);
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-12, 38, 8, 8);
+    } else {
+      context.fillStyle = this.colors.top;
+      context.fillRect(-12, 0, 8, 38);
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-12, 38, 8, 8);
+    }
   };
 
   #drawUpperBody = (context: CanvasRenderingContext2D) => {
-    context.fillStyle = this.colors.top;
-    context.fillRect(-12, -54, 24, 40);
+    if (this.variations.sleeveless) {
+      context.fillStyle = this.colors.top;
+      context.fillRect(-12, -54, 24, 40);
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-8, -56, 14, 8);
+      context.fillRect(-7, -56, 10, 12);
+    } else {
+      context.fillStyle = this.colors.top;
+      context.fillRect(-12, -54, 24, 40);
+    }
   };
 
   #drawLowerBody = (context: CanvasRenderingContext2D) => {

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -23,7 +23,7 @@ type PersonState = {
   barrier: Rect;
 };
 
-type Variation = 'glasses' | 'sunglassses' | 'bald'  ;
+type Variation = 'glasses' | 'sunglassses' | 'bald' | 'beanie' | 'cap';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -74,11 +74,13 @@ export default class Person implements GameObject, PersonState {
   deadAt: number = 0;
 
   variations: {
-    [key in Variation]: boolean;
+    [key in Variation]: boolean | string;
   } = {
     glasses: false,
-    sunglassses: true,
-    bald: true,
+    sunglassses: false,
+    bald: false,
+    beanie: false,
+    cap: false,
   }
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -475,7 +477,7 @@ export default class Person implements GameObject, PersonState {
     context.fillStyle = this.colors.eye;
     context.fillRect(-8, -46, 4, 4);
     context.fillRect(0, -46, 4, 4);
-    if (this.variations.bald) {
+    if (this.variations.bald || this.variations.beanie || this.variations.cap) {
       context.fillStyle = this.colors.skin;
       context.fillRect(-10, -56, 21, 6);
     } else {
@@ -487,6 +489,12 @@ export default class Person implements GameObject, PersonState {
       this.#drawGlasses(context);
     } else if (this.variations.sunglassses) {
       this.#drawSunGlasses(context);
+    }
+    if (this.variations.beanie) {
+      this.#drawBeanie(context);
+    }
+    if (this.variations.cap) {
+      this.#drawCap(context);
     }
   };
 
@@ -855,6 +863,20 @@ export default class Person implements GameObject, PersonState {
     context.fillRect(-12, -48, 8, 8);
     context.fillRect(7, -46, 6, 2);
     context.fillRect(-8, -46, 6, 2);
+  }
+
+  #drawBeanie = (context: CanvasRenderingContext2D) => {
+    context.fillStyle = this.variations.beanie as string;
+    context.fillRect(-12, -60, 24, 6);
+    context.fillRect(-8, -63, 22, 4);
+    context.fillRect(-4, -67, 20, 4);
+    context.fillRect(12, -71, 6, 6);
+  }
+
+  #drawCap = (context: CanvasRenderingContext2D) => {
+    context.fillStyle = this.variations.cap as string;
+    context.fillRect(-18, -52, 30, 4);
+    context.fillRect(-12, -59, 24, 8);
   }
 
   #drawBarrier = (context: CanvasRenderingContext2D) => {

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -37,7 +37,8 @@ type Variation =
   | 'hat'
   | 'longHair'
   | 'short'
-  | 'sleeveless';
+  | 'sleeveless'
+  | 'shortSleeve';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -98,7 +99,8 @@ export default class Person implements GameObject, PersonState {
     hat: false,
     longHair: false,
     short: false,
-    sleeveless: true,
+    sleeveless: false,
+    shortSleeve: true,
   };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -546,6 +548,11 @@ export default class Person implements GameObject, PersonState {
       context.fillRect(-12, 0, 8, 38);
       context.fillStyle = this.colors.skin;
       context.fillRect(-12, 38, 8, 8);
+    } else if (this.variations.shortSleeve) {
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-12, 0, 8, 46);
+      context.fillStyle = this.colors.top;
+      context.fillRect(-14, -1, 12, 20);
     } else {
       context.fillStyle = this.colors.top;
       context.fillRect(-12, 0, 8, 38);

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -1,7 +1,12 @@
 import { GameObject } from '.';
 import canvas, { drawLayer } from '../canvas';
 import { RectType, Rect } from '../types/rect';
-import { degreeToRadian, barrierRectFactory, getRandomIntegerFromRange, getTimings } from '../utils';
+import {
+  degreeToRadian,
+  barrierRectFactory,
+  getRandomIntegerFromRange,
+  getTimings,
+} from '../utils';
 
 type ColorState = {
   hair: string;
@@ -23,7 +28,7 @@ type PersonState = {
   barrier: Rect;
 };
 
-type Variation = 'glasses' | 'sunglassses' | 'bald' | 'beanie' | 'cap';
+type Variation = 'glasses' | 'sunglassses' | 'bald' | 'beanie' | 'cap' | 'hat';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -34,7 +39,7 @@ export const SKIN_COLORS = [
   '#ffdbac',
 ];
 
-export const LOWER_BODY_SIZE = 18
+export const LOWER_BODY_SIZE = 18;
 const PADDING = 10;
 const SPEED_MAX_MULTIPLE = 0.3;
 const SPEED_MIN_MULTIPLE = -0.7;
@@ -46,7 +51,7 @@ const FRAME_RATE_PER_SECOND = 60;
  * @description 1프레임 동안 움직이는 픽셀 거리
  */
 const DEFAULT_SPEED = DISTANCE_PER_SECOND / FRAME_RATE_PER_SECOND;
-const MIN_SPEED = 0.1
+const MIN_SPEED = 0.1;
 
 export default class Person implements GameObject, PersonState {
   id: number;
@@ -81,7 +86,8 @@ export default class Person implements GameObject, PersonState {
     bald: false,
     beanie: false,
     cap: false,
-  }
+    hat: '#000',
+  };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
     this.defaultSpeed = defaultSpeed;
@@ -114,7 +120,9 @@ export default class Person implements GameObject, PersonState {
     ];
 
     const getRandomMoveIndex = () => {
-      const randomIndex = Math.floor(getRandomIntegerFromRange(0, moves.length - 1));
+      const randomIndex = Math.floor(
+        getRandomIntegerFromRange(0, moves.length - 1),
+      );
       return randomIndex;
     };
     const randomizeMoves = () => {
@@ -124,8 +132,14 @@ export default class Person implements GameObject, PersonState {
       this.intervals = [getRandomIntegerFromRange(4_000, 7_000)];
     };
     const randomizeXandY = () => {
-      this.randomX = getRandomIntegerFromRange(SPEED_MIN_MULTIPLE, SPEED_MAX_MULTIPLE);
-      this.randomY = getRandomIntegerFromRange(SPEED_MIN_MULTIPLE, SPEED_MAX_MULTIPLE);
+      this.randomX = getRandomIntegerFromRange(
+        SPEED_MIN_MULTIPLE,
+        SPEED_MAX_MULTIPLE,
+      );
+      this.randomY = getRandomIntegerFromRange(
+        SPEED_MIN_MULTIPLE,
+        SPEED_MAX_MULTIPLE,
+      );
     };
     const randomizeDirection = () => {
       getRandomIntegerFromRange(-1, 1) > 0 && this.#changeDirectionX();
@@ -243,9 +257,9 @@ export default class Person implements GameObject, PersonState {
     const drawLayer1 = drawLayer(layer1);
     const layer2 = canvas.get('layer2'); // 축소
     const drawLayer2 = drawLayer(layer2);
-    
+
     drawLayer1((context, canvas) => {
-      const sizeRatio = 0.6 + 0.4 * (this.position.z / canvas.height);
+      const sizeRatio = 0.4 + 0. * (this.position.y / canvas.offsetHeight);
       this.#setHitBoxPosition();
       this.#drawShadow(context, canvas, time, this.position, sizeRatio);
 
@@ -270,7 +284,7 @@ export default class Person implements GameObject, PersonState {
       }
     });
     drawLayer2((context, canvas) => {
-      this.barrier = barrierRectFactory(canvas)
+      this.barrier = barrierRectFactory(canvas);
 
       // debug
       // this.#drawBarrier(context)
@@ -295,7 +309,7 @@ export default class Person implements GameObject, PersonState {
         this.move.direction.y = -1;
       }
 
-      const sizeRatio = 0.3 + 0.2 * (this.position.z / canvas.height);
+      const sizeRatio = 0.2 + 0.3 * (this.position.y / canvas.offsetHeight);
 
       this.#drawShadow(context, canvas, time, this.position, sizeRatio);
 
@@ -477,7 +491,12 @@ export default class Person implements GameObject, PersonState {
     context.fillStyle = this.colors.eye;
     context.fillRect(-8, -46, 4, 4);
     context.fillRect(0, -46, 4, 4);
-    if (this.variations.bald || this.variations.beanie || this.variations.cap) {
+    if (
+      this.variations.bald ||
+      this.variations.beanie ||
+      this.variations.cap ||
+      this.variations.hat
+    ) {
       context.fillStyle = this.colors.skin;
       context.fillRect(-10, -56, 21, 6);
     } else {
@@ -495,6 +514,9 @@ export default class Person implements GameObject, PersonState {
     }
     if (this.variations.cap) {
       this.#drawCap(context);
+    }
+    if (this.variations.hat) {
+      this.#drawHat(context);
     }
   };
 
@@ -602,16 +624,18 @@ export default class Person implements GameObject, PersonState {
   }
 
   #stayInBarrier() {
-    if (this.position.x < this.barrier.left || 
+    if (
+      this.position.x < this.barrier.left ||
       this.position.x >= this.barrier.right
     ) {
-      this.#changeDirectionX()
+      this.#changeDirectionX();
     }
 
-    if (this.position.y < this.barrier.top ||
+    if (
+      this.position.y < this.barrier.top ||
       this.position.y >= this.barrier.bottom - LOWER_BODY_SIZE
     ) {
-      this.#changeDirectionY()
+      this.#changeDirectionY();
     }
   }
 
@@ -844,7 +868,7 @@ export default class Person implements GameObject, PersonState {
   };
 
   #drawGlasses = (context: CanvasRenderingContext2D) => {
-    context.fillStyle = '#000'
+    context.fillStyle = '#000';
     context.strokeStyle = '#000';
     context.beginPath();
     context.arc(-8, -43, 6, 0, degreeToRadian(360));
@@ -855,15 +879,15 @@ export default class Person implements GameObject, PersonState {
     context.stroke();
     context.fillRect(9, -45, 4, 2);
     context.closePath();
-  }
+  };
 
   #drawSunGlasses = (context: CanvasRenderingContext2D) => {
-    context.fillStyle = '#000'
+    context.fillStyle = '#000';
     context.fillRect(-2, -48, 10, 8);
     context.fillRect(-12, -48, 8, 8);
     context.fillRect(7, -46, 6, 2);
     context.fillRect(-8, -46, 6, 2);
-  }
+  };
 
   #drawBeanie = (context: CanvasRenderingContext2D) => {
     context.fillStyle = this.variations.beanie as string;
@@ -871,18 +895,29 @@ export default class Person implements GameObject, PersonState {
     context.fillRect(-8, -63, 22, 4);
     context.fillRect(-4, -67, 20, 4);
     context.fillRect(12, -71, 6, 6);
-  }
+  };
 
   #drawCap = (context: CanvasRenderingContext2D) => {
     context.fillStyle = this.variations.cap as string;
     context.fillRect(-18, -52, 30, 4);
     context.fillRect(-12, -59, 24, 8);
-  }
+  };
+
+  #drawHat = (context: CanvasRenderingContext2D) => {
+    context.fillStyle = this.variations.hat as string;
+    context.fillRect(-18, -58, 36, 6);
+    context.fillRect(-12, -67, 24, 10);
+  };
 
   #drawBarrier = (context: CanvasRenderingContext2D) => {
-    context.resetTransform()
+    context.resetTransform();
     context.beginPath();
-    context.strokeRect(this.barrier.left, this.barrier.top, this.barrier.width, this.barrier.height);
+    context.strokeRect(
+      this.barrier.left,
+      this.barrier.top,
+      this.barrier.width,
+      this.barrier.height,
+    );
     context.closePath();
-  }
+  };
 }

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -26,11 +26,12 @@ type PersonState = {
   };
   colors: ColorState;
   barrier: Rect;
+  variations: VariationState;
 };
 
 type Variation =
   | 'glasses'
-  | 'sunglassses'
+  | 'sunglasses'
   | 'bald'
   | 'beanie'
   | 'cap'
@@ -40,6 +41,10 @@ type Variation =
   | 'sleeveless'
   | 'shortSleeve'
   | 'shortPants';
+  
+export type VariationState = {
+  [key in Variation]: boolean | string;
+};
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -89,28 +94,14 @@ export default class Person implements GameObject, PersonState {
   correctAt: number = 0;
   deadAt: number = 0;
 
-  variations: {
-    [key in Variation]: boolean | string;
-  } = {
-    glasses: false,
-    sunglassses: false,
-    bald: false,
-    beanie: false,
-    cap: false,
-    hat: false,
-    longHair: false,
-    shortHair: false,
-    sleeveless: false,
-    shortSleeve: true,
-    shortPants: true,
-  };
+  variations: VariationState;
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
     this.defaultSpeed = defaultSpeed;
   }
 
   init = (state: PersonState) => {
-    const { id, position, colors, barrier } = state;
+    const { id, position, colors, barrier, variations } = state;
     this.id = id;
     this.position = position;
     this.move = {
@@ -122,6 +113,7 @@ export default class Person implements GameObject, PersonState {
     };
     this.colors = colors;
     this.barrier = barrier;
+    this.variations = variations;
 
     const moves = [
       ...Array.from({ length: 12 }, () => this.#moveIdle),
@@ -518,8 +510,9 @@ export default class Person implements GameObject, PersonState {
     } else if (this.variations.longHair) {
       context.fillStyle = this.colors.hair;
       context.fillRect(-10, -62, 24, 12);
-      context.fillRect(-14, -62, 4, 16);
-      context.fillRect(8, -58, 12, 48);
+      context.fillRect(-14, -60, 8, 12);
+      context.fillRect(10, -58, 10, 48);
+      context.fillRect(10, -44, 14, 48);
     } else if (this.variations.shortHair) {
       context.fillStyle = this.colors.hair;
       context.fillRect(-8, -62, 20, 12);
@@ -532,7 +525,7 @@ export default class Person implements GameObject, PersonState {
     }
     if (this.variations.glasses) {
       this.#drawGlasses(context);
-    } else if (this.variations.sunglassses) {
+    } else if (this.variations.sunglasses) {
       this.#drawSunGlasses(context);
     }
     if (this.variations.beanie) {
@@ -946,7 +939,7 @@ export default class Person implements GameObject, PersonState {
     context.fillStyle = this.variations.beanie as string;
     context.fillRect(-12, -60, 24, 6);
     context.fillRect(-8, -63, 22, 4);
-    context.fillRect(-4, -67, 20, 4);
+    context.fillRect(-4, -67, 20, 5);
     context.fillRect(12, -71, 6, 6);
   };
 

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -36,9 +36,10 @@ type Variation =
   | 'cap'
   | 'hat'
   | 'longHair'
-  | 'short'
+  | 'shortHair'
   | 'sleeveless'
-  | 'shortSleeve';
+  | 'shortSleeve'
+  | 'shortPants';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -98,9 +99,10 @@ export default class Person implements GameObject, PersonState {
     cap: false,
     hat: false,
     longHair: false,
-    short: false,
+    shortHair: false,
     sleeveless: false,
     shortSleeve: true,
+    shortPants: true,
   };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -518,7 +520,7 @@ export default class Person implements GameObject, PersonState {
       context.fillRect(-10, -62, 24, 12);
       context.fillRect(-14, -62, 4, 16);
       context.fillRect(8, -58, 12, 48);
-    } else if (this.variations.short) {
+    } else if (this.variations.shortHair) {
       context.fillStyle = this.colors.hair;
       context.fillRect(-8, -62, 20, 12);
       context.fillRect(-14, -60, 9, 16);
@@ -580,10 +582,19 @@ export default class Person implements GameObject, PersonState {
   };
 
   #drawLeg = (context: CanvasRenderingContext2D) => {
-    context.fillStyle = this.colors.bottom;
-    context.fillRect(-12, 0, 10, 24);
-    context.fillStyle = this.colors.shoe;
-    context.fillRect(-14, 23, 12, 8);
+    if (this.variations.shortPants) {
+      context.fillStyle = this.colors.skin;
+      context.fillRect(-10, 6, 8, 20);
+      context.fillStyle = this.colors.bottom;
+      context.fillRect(-12, -2, 10, 12);
+      context.fillStyle = this.colors.shoe;
+      context.fillRect(-14, 23, 12, 8);
+    } else {
+      context.fillStyle = this.colors.bottom;
+      context.fillRect(-12, 0, 10, 24);
+      context.fillStyle = this.colors.shoe;
+      context.fillRect(-14, 23, 12, 8);
+    }
   };
 
   #setHitBoxPosition = () => {

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -259,7 +259,7 @@ export default class Person implements GameObject, PersonState {
     const drawLayer2 = drawLayer(layer2);
 
     drawLayer1((context, canvas) => {
-      const sizeRatio = 0.4 + 0. * (this.position.y / canvas.offsetHeight);
+      const sizeRatio = 0.4 + 0.6 * (this.position.y / canvas.offsetHeight);
       this.#setHitBoxPosition();
       this.#drawShadow(context, canvas, time, this.position, sizeRatio);
 

--- a/src/objects/person.ts
+++ b/src/objects/person.ts
@@ -28,7 +28,14 @@ type PersonState = {
   barrier: Rect;
 };
 
-type Variation = 'glasses' | 'sunglassses' | 'bald' | 'beanie' | 'cap' | 'hat';
+type Variation =
+  | 'glasses'
+  | 'sunglassses'
+  | 'bald'
+  | 'beanie'
+  | 'cap'
+  | 'hat'
+  | 'longHair';
 
 export const EYE_COLORS = ['#634e34', '#2e536f', '#1c7847'];
 export const SKIN_COLORS = [
@@ -86,7 +93,8 @@ export default class Person implements GameObject, PersonState {
     bald: false,
     beanie: false,
     cap: false,
-    hat: '#000',
+    hat: false,
+    longHair: true,
   };
 
   constructor(defaultSpeed: number = DEFAULT_SPEED) {
@@ -499,6 +507,11 @@ export default class Person implements GameObject, PersonState {
     ) {
       context.fillStyle = this.colors.skin;
       context.fillRect(-10, -56, 21, 6);
+    } else if (this.variations.longHair) {
+      context.fillStyle = this.colors.hair;
+      context.fillRect(-10, -62, 24, 12);
+      context.fillRect(-14, -62, 4, 16);
+      context.fillRect(8, -58, 12, 48);
     } else {
       context.fillStyle = this.colors.hair;
       context.fillRect(-16, -62, 28, 12);

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -15,6 +15,7 @@ import {
   getRandomIntegerFromRange,
   pickRandomOption,
   isInsideRect,
+  pickPersonVariations,
 } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
@@ -100,6 +101,7 @@ export default class PlayScene implements Scene {
           shoe: getRandomColor(),
         },
         barrier: this.barrier,
+        variations: pickPersonVariations(),
       });
     });
 

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -16,6 +16,7 @@ import {
   pickRandomOption,
   isInsideRect,
   pickPersonVariations,
+  getMousePosition,
 } from '../utils';
 import WantedPoster from '../objects/wantedPoster';
 import Music from '../sounds/music';
@@ -165,10 +166,9 @@ export default class PlayScene implements Scene {
     this.persons.forEach((person) => {
       if (person.isHit) return;
 
-      isInsideRect({
-        x: e.offsetX,
-        y: e.offsetY,
-      }, person.hitBoxPosition) && clickedPersons.push(person);
+      const position = getMousePosition(this.layer1, e);
+
+      isInsideRect(position, person.hitBoxPosition) && clickedPersons.push(person);
     })
 
     const [frontPerson] = clickedPersons.sort((a, b) => b.position.y - a.position.y);

--- a/src/scenes/title.ts
+++ b/src/scenes/title.ts
@@ -10,6 +10,7 @@ import { setIsSoundOn } from '../store/mutation';
 import {
   degreeToRadian,
   getFont,
+  getMousePosition,
   isInsideRect,
   isMobileSize,
   isTabletSize,
@@ -159,15 +160,15 @@ export default class TitleScene implements Scene {
   };
 
   #handleClickEvent = (e: PointerEvent) => {
-    const { offsetX, offsetY } = e;
+    const position = getMousePosition(e.target as HTMLCanvasElement, e);
 
-    if (isInsideRect({ x: offsetX, y: offsetY }, this.hitBoxes.start)) {
+    if (isInsideRect(position, this.hitBoxes.start)) {
       this.activeMenuIndex = 0;
       const currentMenu = this.menus[this.activeMenuIndex];
       currentMenu.action();
     }
 
-    if (isInsideRect({ x: offsetX, y: offsetY }, this.hitBoxes.sound)) {
+    if (isInsideRect(position, this.hitBoxes.sound)) {
       this.activeMenuIndex = 1;
       const currentMenu = this.menus[this.activeMenuIndex];
       currentMenu.action();
@@ -177,11 +178,7 @@ export default class TitleScene implements Scene {
   };
 
   #pointerEvent = (e: PointerEvent) => {
-    const { offsetX, offsetY } = e;
-    const position = {
-      x: offsetX,
-      y: offsetY,
-    };
+    const position =  getMousePosition(e.target as HTMLCanvasElement, e);
 
     Object.assign(this.magnifier, position);
 
@@ -192,16 +189,6 @@ export default class TitleScene implements Scene {
     if (isInsideRect(position, this.hitBoxes.sound)) {
       this.activeMenuIndex = 1;
     }
-  };
-
-  #changeScene = (sceneType: SceneType) => {
-    window.postMessage(
-      {
-        type: 'change-scene',
-        payload: sceneType,
-      },
-      window.origin,
-    );
   };
 
   #drawLayer0 = drawLayer(canvas.get('layer0'));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { VariationState } from './objects/person';
 import { Rect, RectType } from './types/rect';
 
 export const degreeToRadian = (degree: number) => (Math.PI / 180) * degree;
@@ -91,3 +92,49 @@ export const barrierRectFactory = (canvas: HTMLCanvasElement) => {
   })
 }
 
+export const pickPersonVariations = (): VariationState => {
+  const pickEyeWear = () => {
+    const randomInt = getRandomInt(10);
+    return {
+      glasses: randomInt < 2,
+      sunglasses: randomInt > 7,
+    };
+  }
+  const pickHead = () => {
+    const randomInt = getRandomInt(10);
+    return {
+      bald: randomInt === 0,
+      beanie: randomInt === 1 && getRandomColor(),
+      cap: randomInt === 2 && getRandomColor(),
+      hat: randomInt === 3 && getRandomColor(),
+    };
+  }
+  const pickHair = () => {
+    const randomInt = getRandomInt(3);
+    return {
+      longHair: randomInt === 0,
+      shortHair: randomInt === 1,
+    };
+  }
+  const pickTopWear = () => {
+    const randomInt = getRandomInt(3);
+    return {
+      sleeveless: randomInt === 0,
+      shortSleeve: randomInt === 1,
+    };
+  }
+  const pickBottomWear = () => {
+    const randomInt = getRandomInt(2);
+    return {
+      shortPants: randomInt === 0,
+    };
+  }
+  
+  return {
+    ...pickEyeWear(),
+    ...pickHead(),
+    ...pickHair(),
+    ...pickTopWear(),
+    ...pickBottomWear(),
+  };
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,3 +138,11 @@ export const pickPersonVariations = (): VariationState => {
     ...pickBottomWear(),
   };
 };
+
+export const getMousePosition = (canvas: HTMLCanvasElement, e: MouseEvent) => {
+  const rect = canvas.getBoundingClientRect();
+  return {
+      x: (e.clientX - rect.left) / (rect.right - rect.left) * canvas.width,
+      y: (e.clientY - rect.top) / (rect.bottom - rect.top) * canvas.height
+  };
+}


### PR DESCRIPTION
### 작업 내용
- Person에 기존 그리기에 추가로 다음과 같은 바이레이션들을 추가합니다.
  - 안경 / 선글라스
  - 대머리 / 비니 / 캡 / 햇
  - 긴머리 / 짧은머리
  - 나시 / 반팔
  - 반바지
- `resizeCanvas`에서 캔버스 크기를 직접 조정하는 대신, 크기 자체는 고정값으로 두고 캔버스의 스타일을 조정하여 화면에 꽉 차도록 합니다. 이러한 조정이 필요했던 이유에 대해서는 아래에서 설명합니다. (최적의 width, height 값을 찾아내진 않았습니다. 이따 논의하면서 정해보겠습니다.)

#### 변경 전 
- 캔버스에서 그리는 영역은 그대로인데, 캔버스 크기만 줄어들어서, 뷰포트 사이즈가 줄어들면 저희가 의도했던 형태로 그려지지 않는 문제가 있습니다.
![image](https://user-images.githubusercontent.com/54790378/189511403-252f7d0c-f4e5-401c-9dcc-bd3b68440092.png)

#### 변경 후
- 캔버스 크기는 고정으로 두고, 스타일을 통해 보여지는 사이즈만 조절하여, 크기 자체는 줄어들지만 여전히 화면 내에 의도하고자 했던 형태나 비율은 동일해졌습니다.
![image](https://user-images.githubusercontent.com/54790378/189511418-cee1edf4-343d-4636-9138-cb4fdfc91711.png)

- 앞선 변경 사항에 따라, 기존 `offsetX`, `offsetY`로는 제대로 된 마우스 포지션 파악을 할 수 없게 되어, 이를 대체하기 위해 새로 `getMousePosition` 유틸을 추가하여, 기존에 사용하던 부분들을 대체합니다.
- 작업을 하다보니 은연 중에 사라졌던 y축 변경에 따른 person 사이즈 변경을 다시 추가합니다.