### PR TITLE
Game Result 씬 추가

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -1,3 +1,4 @@
+import { GameResultSceneState } from './scenes/gameResult';
 import { GameOverSceneState } from './scenes/gameover';
 import { PlaySceneState } from './scenes/play';
 
@@ -17,6 +18,10 @@ export type ChangeSceneEvent = {
     | {
         type: 'title';
         state: null;
+      }
+    | {
+        type: 'gameResult';
+        state: GameResultSceneState;
       };
 };
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,6 +1,7 @@
 import { resetAllLayers } from './canvas';
 import { ChangeSceneEvent, listenGlobalEvent } from './event';
 import { PlayScene, TitleScene, Scene, SceneType } from './scenes';
+import GameResultScene from './scenes/gameResult';
 import GameOverScene from './scenes/gameover';
 
 export default class Game {
@@ -13,6 +14,7 @@ export default class Game {
       play: new PlayScene(),
       title: new TitleScene(),
       gameover: new GameOverScene(),
+      gameResult: new GameResultScene(),
     };
   }
 

--- a/src/objects/playInfo.ts
+++ b/src/objects/playInfo.ts
@@ -14,6 +14,7 @@ export default class PlayInfo implements GameObject, PlayInfoState {
   startTime: number; // ms
   timeout: number; // ms
   lifeCount: number;
+  remainTime: string;
 
   constructor() {
     this.layer = canvas.get('layer3');
@@ -51,13 +52,13 @@ export default class PlayInfo implements GameObject, PlayInfoState {
     const draw = drawLayer(this.layer);
 
     draw((context, canvas) => {
-      const remainTime = (
+      this.remainTime = (
         Math.max(this.timeout - (time - this.startTime), 0) / 1000
       ).toFixed(2);
 
       context.setTransform(1, 0, 0, 1, canvas.width, 0);
       context.font = getFont(24);
-      context.fillText(remainTime + '', -(40 + 92), 56);
+      context.fillText(this.remainTime + '', -(40 + 92), 56);
     });
   };
 

--- a/src/objects/playInfo.ts
+++ b/src/objects/playInfo.ts
@@ -14,7 +14,7 @@ export default class PlayInfo implements GameObject, PlayInfoState {
   startTime: number; // ms
   timeout: number; // ms
   lifeCount: number;
-  remainTime: string;
+  elapsedTime: string;
 
   constructor() {
     this.layer = canvas.get('layer3');
@@ -52,13 +52,15 @@ export default class PlayInfo implements GameObject, PlayInfoState {
     const draw = drawLayer(this.layer);
 
     draw((context, canvas) => {
-      this.remainTime = (
+      const remainTime = (
         Math.max(this.timeout - (time - this.startTime), 0) / 1000
       ).toFixed(2);
 
+      this.elapsedTime = ((time - this.startTime) / 1000).toFixed(2);
+
       context.setTransform(1, 0, 0, 1, canvas.width, 0);
       context.font = getFont(24);
-      context.fillText(this.remainTime + '', -(40 + 92), 56);
+      context.fillText(remainTime + '', -(40 + 92), 56);
     });
   };
 

--- a/src/scenes/gameResult.ts
+++ b/src/scenes/gameResult.ts
@@ -1,0 +1,129 @@
+import { Scene } from ".";
+import canvasMap, { drawLayer } from "../canvas";
+import { STAGE_STATES } from "../constants";
+import { postGlobalEvent } from "../event";
+import Music from "../sounds/music";
+import resultMusic from "../sounds/musics/result";
+import { getFont } from "../utils";
+
+const lastStage = Math.max(...Object.keys(STAGE_STATES).map(Number))
+
+export type GameResultSceneState = {
+  stage: number;
+  clearTime: string;
+};
+
+export default class GameResultScene implements Scene {
+  stage: number;
+  music: Music;
+  elements: {
+    buttonContainer: HTMLDivElement;
+    nextButton: HTMLButtonElement;
+  };
+  nextStage: number | undefined;
+  clearTime: string;
+
+  constructor() {
+    this.music = new Music(resultMusic);
+  }
+
+  start = ({ stage, clearTime }: GameResultScene) => {
+    this.stage = stage;
+    this.clearTime = clearTime;
+    this.nextStage = this.stage < lastStage ? this.stage + 1 : undefined;
+
+    this.music.play(false);
+    this.#appendButtons();
+    this.#addEventListeners();
+  }
+
+  update = (time: number) => {
+    const layer1 = canvasMap.get('layer1');
+    const drawLayer1 = drawLayer(layer1);
+
+    drawLayer1((context, canvas) => {
+      context.setTransform(1, 0, 0, 1, canvas.width / 2, canvas.height / 2)
+      this.#drawTitle(context);
+
+      context.transform(1, 0, 0, 1, 0, 140)
+      this.#drawResult(context);
+    });
+  }
+
+  end = () => {
+    this.music.stop();
+    this.#removeEventListeners();
+    this.elements.buttonContainer.remove();
+  }
+
+  #drawTitle = (context: CanvasRenderingContext2D) => {
+    const title = this.nextStage ? 'Stage Clear' : 'Complete';
+    context.font = getFont(64)
+    context.fillStyle = 'white';
+    context.fillText(title, context.measureText(title).width / 2 * -1, -120); 
+  }
+
+  #drawResult = (context: CanvasRenderingContext2D) => {
+    const result = `Time: ${this.clearTime}`;
+    context.font = getFont(28)
+    context.fillStyle = 'white';
+    context.fillText(result, context.measureText(result).width / 2 * -1, -120);
+  }
+
+  #appendButtons = () => {
+    const buttonContainer = document.createElement('div');
+    buttonContainer.style.cssText = `
+      display: flex;  
+      width: 480px;
+      height: 80%;
+      margin: 0 auto;
+      justify-content: center;
+      align-items: flex-end;
+    `;
+    const nextButton = document.createElement('button');
+    nextButton.style.cssText = `
+      background: none;
+      border: none;
+      font-size: 40px;
+      color: #fff;
+      z-index: 11;
+      cursor: pointer;
+    `;
+    nextButton.textContent = this.nextStage ? 'Next' : 'Menu';
+    buttonContainer.append(nextButton);
+    document.body.append(buttonContainer);
+    this.elements = {
+      buttonContainer,
+      nextButton: nextButton,
+    };
+  }
+
+  #handleClickNext = () => {
+    if (!this.nextStage) {
+      postGlobalEvent({
+        type: 'change-scene',
+        payload: {
+          type: 'title',
+          state: null,
+        }
+      })  
+      return;
+    }
+
+    postGlobalEvent({
+      type: 'change-scene',
+      payload: {
+        type: 'play',
+        state: STAGE_STATES[this.nextStage]
+      }
+    })
+  }
+
+  #addEventListeners = () => {
+    this.elements.nextButton.addEventListener('click', this.#handleClickNext);
+  }
+
+  #removeEventListeners = () => {
+    this.elements.nextButton.removeEventListener('click', this.#handleClickNext);
+  }
+}

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,7 +1,7 @@
 import PlayScene from './play';
 import TitleScene from './title';
 
-export type SceneType = 'play' | 'title' | 'gameover';
+export type SceneType = 'play' | 'title' | 'gameover' | 'gameResult';
 
 export interface Scene {
   start: (...args: any) => void;

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -129,6 +129,7 @@ export default class PlayScene implements Scene {
     this.magnifier.update(time);
     this.wantedPoster.update(time);
     this.#checkGameOver();
+    this.#checkGameResult();
   };
 
   end = () => {
@@ -155,6 +156,22 @@ export default class PlayScene implements Scene {
     }
   };
 
+  #checkGameResult = () => {
+    if (this.wantedPoster.persons.length === 0) {
+      this.music.stop();
+      postGlobalEvent({
+        type: 'change-scene',
+        payload: {
+          type: 'gameResult',
+          state: {
+            stage: this.info.stage,
+            clearTime: this.info.remainTime,
+          },
+        },
+      });
+    }
+  };
+
   #handleClickPerson = (e: PointerEvent) => {
     let isPersonClicked = false;
     let isCorrect = false;
@@ -170,6 +187,7 @@ export default class PlayScene implements Scene {
     })
 
     const [frontPerson] = clickedPersons.sort((a, b) => b.position.y - a.position.y);
+    if (!frontPerson) return;
     frontPerson.isHit = true;
 
     if (frontPerson.isHit) {

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -165,7 +165,7 @@ export default class PlayScene implements Scene {
           type: 'gameResult',
           state: {
             stage: this.info.stage,
-            clearTime: this.info.remainTime,
+            clearTime: this.info.elapsedTime,
           },
         },
       });


### PR DESCRIPTION
## 작업 내용

- 지명수배인을 모두 잡으면 game result 씬을 보여줍니다.
- game result에서는 clear time 기록을 볼 수 있습니다.
- game result에서 next 버튼을 누르면 다음 stage로 넘어갑니다.
- 마지막 stage를 깨면 game result에서 clear time과 menu 버튼을 보여줍니다.
- 스테이지를 깨면 Stage Clear라는 텍스트를 보여주고, 모든 스테이지를 클리어하면 Complete 텍스트를 보여줍니다.

> [참조 이미지](https://geektogeekmedia.com/wp-content/uploads/2021/04/smelter-32-1024x576.jpg.webp)

## 기타 사항

- 스테이지에서 사람이 아닌 곳을 체크했을 때 frontPerson에 대한 로직을 수행하지 않도록 얼리 리턴을 추가합니다.

## 데모

https://user-images.githubusercontent.com/8105528/189512310-77cbd42d-61db-4745-9ac7-18aba2b3195c.mov

