### PR TITLE
fix: Github Pages 배포 워크플로가 계속해서 깨지는 문제 수정

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,7 @@
 name: Deploy to GitHub Pages
-on: push
+on:
+  push:
+    branches: [master]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build & Deploy to GitHub Pages
 on:
   push:
     branches: [master]

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,20 +1,39 @@
-name: Build & Deploy to Github Pages
-on:
-  push:
-    branches: [master]
-  workflow_dispatch:
+name: Deploy to GitHub Pages
+on: push
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
+    name: Build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1
-      - name: Install & Build
-        run: |
-          npm install
-          npm run build
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+      - uses: actions/checkout@v3.4.0
+      - uses: actions/configure-pages@v3.0.5
+      - name: Set Node.js 18.x
+        uses: actions/setup-node@v3.6.0
         with:
-          branch: deploy
-          folder: ./dist
+          node-version: 18
+      - name: Install dependencies
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+      - name: Build production bundle
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: build
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          path: "dist/"
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-typescript": "^7.15.0",
     "@types/jest": "^28.1.7",
     "babel-jest": "^28.1.3",
+    "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",

--- a/src/scenes/gameOver.ts
+++ b/src/scenes/gameOver.ts
@@ -2,7 +2,7 @@ import { Scene } from '.';
 import { STAGE_STATES } from '../constants';
 import { postGlobalEvent } from '../event';
 import Music from '../sounds/music';
-import gameoverMusic from '../sounds/musics/gameover';
+import gameOverMusic from '../sounds/musics/gameOver';
 
 export type GameOverSceneState = {
   stage: number;
@@ -18,7 +18,7 @@ export default class GameOverScene implements Scene {
   };
 
   constructor() {
-    this.music = new Music(gameoverMusic);
+    this.music = new Music(gameOverMusic);
   }
 
   start = ({ stage }: GameOverSceneState) => {

--- a/src/sounds/musics/gameOver.ts
+++ b/src/sounds/musics/gameOver.ts
@@ -1,4 +1,4 @@
-const gameoverMusic = [
+const gameOverMusic = [
   [[0.5, 0, 320, , 0.1, 0.5, , , , , 20]],
   [
     [
@@ -41,4 +41,4 @@ const gameoverMusic = [
   96,
 ];
 
-export default gameoverMusic;
+export default gameOverMusic;

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -2,8 +2,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const BundleAnalyzerPlugin =
-  require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 module.exports = {
   entry: './src/index.ts',
@@ -28,7 +27,7 @@ module.exports = {
     extensions: ['.ts', '.js'],
   },
   plugins: [
-    // new BundleAnalyzerPlugin(),
+    new CaseSensitivePathsPlugin(),
     new MiniCssExtractPlugin(),
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,6 +2070,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001370:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz#010d9d56e3b8abcd8df261d0a94b22426271a15f"
   integrity sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==
 
+case-sensitive-paths-webpack-plugin@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz#db64066c6422eed2e08cc14b986ca43796dbc6d4"
+  integrity sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
## 작업 내용
- Github Pages로의 빌드 및 배포를 담당하는 github workflow를 수정합니다.
  - 원래는 [Jameslves라는 분이 만들어준 액션](https://github.com/JamesIves/github-pages-deploy-action)을 쓰고 있었는데, [Github Action 쪽에서 공식적으로 나온 액션](https://github.com/marketplace/actions/deploy-github-pages-site)을 쓰도록 수정했습니다. (아직 베타버전이긴 하지만)
- 파일명을 포함하여 `gameover` 명칭의 케이스를 모두 일치시킵니다.
- [case-sensitive-paths-webpack-plugin](https://www.npmjs.com/package/case-sensitive-paths-webpack-plugin)을 빌드 플러그인에 추가하여 macOS에서도 빌드 작업 자체는 case-sensitive하게 이루어지도록 수정합니다. (로컬 작업 시점에서도 문제를 파악할 수 있도록 하여 비슷한 문제의 재발을 방지합니다.)

## 배경
### 이슈
- 저희 컴피티션 페이지 말고도, 현재 master 브랜치를 `https://shubidumdu.github.io/finn-the-little-collector/`에 배포하여 최신 마스터의 내용을 바로바로 확인할 수 있도록 해놓은 워크플로가 있었는데, 언제부턴가 이게 깨지고 있었습니다. 
<img width="538" alt="image" src="https://user-images.githubusercontent.com/54790378/231634186-d1107695-d893-4863-aa44-cc2fe17e0d30.png">

### 원인
- 정확하게는 #26 PR의 작업 내용이 원인입니다. 여기서 `gameover.ts` 파일의 케이스를 변경할 의도셨던 것 같으나, 정작 커밋에는 이러한 파일명 변경이 반영되지 않았습니다. 결국, 해당 파일에 의존하는 다른 파일에서는 빌드 시점에 `[...]/gameOver`를 참조하려 하나, 실제 파일명은 여전히 `gameover.ts`이기 때문에 github action 배포 시점에서 문제가 발생합니다.
![image](https://user-images.githubusercontent.com/54790378/231636007-a966f253-db2e-40c6-81f5-636c436f01e4.png)

### 근데 왜 로컬에서 빌드를 할 때는 문제가 없었죠?
[macOS의 파일 시스템 자체가 case-insensitive하기 때문입니다.](https://discussions.apple.com/thread/251191099)
반면, github workflow에서 사용하는 ubuntu는 case-sensitive하기 때문에, 둘 사이의 빌드 환경에 차이가 발생합니다.
git의 경우에도, macOS 환경에서는 `core.ignorecase`옵션이 `true`로 기본값이 설정되어 있기 때문에, 역시 케이스에 민감하지 않게 동작합니다.
> 결국, macOS같은 case-insensitive 파일 시스템 환경에서는 파일명의 케이스만 변경하여 커밋을 하고 싶을 때는 직접 [`git mv`](https://git-scm.com/docs/git-mv) 명령을 써야합니다. - [참고](https://stackoverflow.com/questions/8904327/case-sensitivity-in-git)